### PR TITLE
Updates title to match the "new" domain.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ destination: ./_site
 lsi: false
 pygments: true
 auto: true
-title: ajsharma.github.com
+title: ajsharma.github.io
 description: 
 google_analytics: UA-39440617-1
 show_downloads: true


### PR DESCRIPTION
GitHub pages have been github.io for a while.